### PR TITLE
fixed UPDServer: print sentence with incoming string length instead o…

### DIFF
--- a/JavaSockets/src/sockets_udp/UDPServer.java
+++ b/JavaSockets/src/sockets_udp/UDPServer.java
@@ -23,7 +23,7 @@ public class UDPServer {
             serverSocket.receive(receivePacket);
             
             // Μετατροπή των ληφθέντων δεδομένων σε συμβολοσειρά (string)
-            String sentence = new String(receivePacket.getData());
+            String sentence = new String(receivePacket.getData(), 0, receivePacket.getLength());
             InetAddress IPAddress = receivePacket.getAddress();
             int port = receivePacket.getPort();
             


### PR DESCRIPTION
fixed error where UDPServer prints a hardcoded length sentence filling with [][][] when input is shorter than 1024